### PR TITLE
Bug/fe51/user is owner validation

### DIFF
--- a/components/Account/UserAccount/sections/Configuration.js
+++ b/components/Account/UserAccount/sections/Configuration.js
@@ -30,7 +30,7 @@ export default function Configuration(props) {
                     user={ user }
                     logout={ logout }
                 />
-                { user?.isowner === IS_OWNER &&
+                { user?.isOwner === IS_OWNER &&
                     <SystemSettings
                         logout={ logout }
                         setReloadUser={ setReloadUser }


### PR DESCRIPTION
This Pull Request is to fix the validation of the user owner, since the property evaluated isOwner now is retrieved by the backend in camel case.